### PR TITLE
Remove tmux as the default shell

### DIFF
--- a/src/shell/.bash_profile
+++ b/src/shell/.bash_profile
@@ -36,15 +36,3 @@ source_bash_files() {
 
 source_bash_files
 unset -f source_bash_files
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-# Change default shell to tmux
-if [[ -x "$(command -v tmux)" ]]; then
-
-  # Additional check to not run tmux within itself
-  #
-  # https://unix.stackexchange.com/a/113768
-  [[ "$TERM" != "screen" ]] && [ -z "$TMUX" ] && exec tmux
-
-fi

--- a/src/shell/.bashrc
+++ b/src/shell/.bashrc
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 [ -n "$PS1" ] && . "$HOME/.bash_profile"
+


### PR DESCRIPTION
tmux takes a hell of a time to bootup and is a bit hard to learn, so use it only when needed